### PR TITLE
use GITHUB_HEAD_REF env variable for branch name in PR

### DIFF
--- a/hypertrace-gradle-docker-plugin/src/main/java/org/hypertrace/gradle/docker/DockerPlugin.java
+++ b/hypertrace-gradle-docker-plugin/src/main/java/org/hypertrace/gradle/docker/DockerPlugin.java
@@ -113,6 +113,9 @@ public class DockerPlugin implements Plugin<Project> {
       // Use the value of CIRCLE_BRANCH/ GITHUB_REF environment variable if defined (that is, the branch name used
       // to build in CI), otherwise for local builds use 'test'
       return getEnvironmentVariable("CIRCLE_BRANCH")
+          // GITHUB_HEAD_REF Only set for pull request events. The name of the head branch.
+          .or(()-> getEnvironmentVariable("GITHUB_HEAD_REF"))
+          // GITHUB_REF The branch or tag ref that triggered the workflow.
           .or(()-> getEnvironmentVariable("GITHUB_REF"))
            // Extracting BRANCH_NAME from GITHUB_REF environment variable which is normally in `refs/heads/{BRANCH_NAME} format.
           .map(branch -> branch.replaceAll("refs\\/heads\\/", ""))


### PR DESCRIPTION
In case of PR, value of env variable `GITHUB_REF` is in the format of `refs/pull/57/merge` and docker tag is returned as `refspull57merge`. 

This change use the value of env variable `GITHUB_HEAD_REF` which is only in case of PR.