### PR TITLE
feat: add config to expose more than one port from image

### DIFF
--- a/hypertrace-gradle-docker-java-application-plugin/CHANGELOG.md
+++ b/hypertrace-gradle-docker-java-application-plugin/CHANGELOG.md
@@ -2,28 +2,22 @@
 
 
 ## [0.2.4]
-### Changed
 - Default image has changed from gcr.io/distroless/java:11 to gcr.io/distroless/java:11-debug
 
 ## [0.3.0]
-### Changed
 - Added support for producing multiple variants of an application with different base images
 - Added a default variant, `slim` based off `gcr.io/distroless/java:11`
 
 ## [0.3.2]
-### Changed
 - Removed default `slim` variant
 
 ## [0.3.3]
-### Changed
 - Support Java 8+
 
 ## [0.4.0]
-### Changed
 - Change default image to `hypertrace/java:11`
 
 ## [0.5.0]
-### Changed
 - Exposed for configuration:
     - `maintainer`
     - `port`
@@ -32,17 +26,17 @@
     - `healthCheck`
     - `envVars`
 ## [0.7.0]
-### Changed
 - Remove variants
 - Remove internal usage of `com.bmuschko.docker-java-application`, cleaning up ghost tasks
 - Use gradle application start script to run application in docker, allowing reuse and accounting
   for env vars like JAVA_OPTS
 
 ## [0.7.1]
-### Changed
 - Simplify start script to use provided parameters as given
 
 ## [0.8.0]
-### Changed
 - Add COMMIT_SHA to the generated dockerfile as a build arg defaulting to unknown
 - Use COMMIT_SHA build arg to set a label `commit_sha` and environment variable `COMMIT_SHA`
+
+## [0.8.2]
+- Add support for exposing multiple docker image ports via `ports` config

--- a/hypertrace-gradle-docker-java-application-plugin/README.md
+++ b/hypertrace-gradle-docker-java-application-plugin/README.md
@@ -20,6 +20,11 @@ An application can define multiple variants which allow specifying different bas
     - Integer
     - No default
     - Exposed in dockerfile if set
+- `ports`
+  - List<Integer>
+  - No default
+  - Exposed in dockerfile if set
+  - This is equivalent to the singular form, with the exception it does not default the admin port
 - `adminPort`
     - Integer
     - If `port` is set, `adminPort` will default to `${port} + 1`

--- a/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplication.java
+++ b/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplication.java
@@ -3,6 +3,7 @@ package org.hypertrace.gradle.docker;
 import java.util.Collections;
 import javax.inject.Inject;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 
@@ -13,6 +14,7 @@ public class HypertraceDockerJavaApplication {
   public final Property<String> serviceName;
   public final Property<Integer> port;
   public final Property<Integer> adminPort;
+  public final ListProperty<Integer> ports;
   public final Property<String> healthCheck;
   public final MapProperty<String, String> envVars;
 
@@ -26,6 +28,7 @@ public class HypertraceDockerJavaApplication {
     this.serviceName = objectFactory.property(String.class)
                                     .convention(projectName);
     this.port = objectFactory.property(Integer.class);
+    this.ports = objectFactory.listProperty(Integer.class);
     this.adminPort = objectFactory.property(Integer.class)
                                   .convention(this.port.map(port -> port + 1));
     this.envVars = objectFactory.mapProperty(String.class, String.class)

--- a/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplicationPlugin.java
+++ b/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplicationPlugin.java
@@ -130,6 +130,9 @@ public class HypertraceDockerJavaApplicationPlugin implements Plugin<Project> {
                if (javaApplication.adminPort.isPresent()) {
                  ports.add(javaApplication.adminPort.get());
                }
+               if (javaApplication.ports.isPresent()) {
+                 ports.addAll(javaApplication.ports.get());
+               }
                return ports;
              }));
            });

--- a/hypertrace-gradle-docker-plugin/CHANGELOG.md
+++ b/hypertrace-gradle-docker-plugin/CHANGELOG.md
@@ -2,24 +2,22 @@
 
 
 ## [0.3.0]
-### Changed
 - Added support for latest tag, which defaults to enabled
 - Added support for remapping tags at an image level
 
 ## [0.3.3]
-### Changed
 - Support Java 8+
 
 ## [0.6.0]
-### Changed
 - Only use version tags for release versions (not containing the string `SNAPSHOT`). For all builds,
 tag using the `CIRCLE_BRANCH` env variable if defined, else `test`
 
 ## [0.6.1]
-### Fixed
 - Disregard empty values for `CIRCLE_BRANCH` and only use branch name for non-release versions
 
 ## [0.8.0]
-### Changed
 - Make `COMMIT_SHA` available as a build arg if the SHA can be determined from the environment.
 This currently uses the variable `CIRCLE_SHA1` but further resolution may be added in the future.
+
+## [0.8.1]
+- Add support for getting tag via `GITHUB_REF` env variable as a fallback from `CIRCLE_BRANCH`

--- a/hypertrace-gradle-docker-publish-plugin/CHANGELOG.md
+++ b/hypertrace-gradle-docker-publish-plugin/CHANGELOG.md
@@ -1,5 +1,4 @@
 # Changelog
 
 ## [0.3.3]
-### Changed
 - Support Java 8+


### PR DESCRIPTION
## Description
This change adds support to the docker java application plugin to expose multiple ports rather than limiting to one. It's backwards compatible and either the singular or plural form can be used. Also did a bit of cleanup of changelogs when updating them.

### Testing
Manually verified behavior

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
