### PR TITLE
docs: clarify port-ports relationship

### DIFF
--- a/hypertrace-gradle-docker-java-application-plugin/README.md
+++ b/hypertrace-gradle-docker-java-application-plugin/README.md
@@ -19,12 +19,12 @@ An application can define multiple variants which allow specifying different bas
 - `port`
     - Integer
     - No default
-    - Exposed in dockerfile if set
+    - Exposed in dockerfile if set. This can be used in conjunction with, or in place of `ports` - the combined list will be exposed.
 - `ports`
   - List<Integer>
   - No default
-  - Exposed in dockerfile if set
-  - This is equivalent to the singular form, with the exception it does not default the admin port
+  - Exposed in dockerfile if set. This can be used in conjunction with, or in place of `port` - the combined list will be exposed.
+  - This does not set a default for the admin port (compared to `port` which does)
 - `adminPort`
     - Integer
     - If `port` is set, `adminPort` will default to `${port} + 1`

--- a/hypertrace-gradle-docker-java-application-plugin/README.md
+++ b/hypertrace-gradle-docker-java-application-plugin/README.md
@@ -16,19 +16,19 @@ An application can define multiple variants which allow specifying different bas
 - `maintainer`
     - String
     - Defaults to `Hypertrace 'https://www.hypertrace.org/'`
-- `port`
+- `port` (_DEPRECATED_ - replaced by `ports`)
     - Integer
     - No default
-    - Exposed in dockerfile if set. This can be used in conjunction with, or in place of `ports` - the combined list will be exposed.
+    - Exposed in dockerfile if set. If used in conjunction with `ports`, the combined list will be exposed.
 - `ports`
-  - List<Integer>
+  - Integer List
   - No default
-  - Exposed in dockerfile if set. This can be used in conjunction with, or in place of `port` - the combined list will be exposed.
-  - This does not set a default for the admin port (compared to `port` which does)
+  - Exposed in dockerfile if set. If used in conjunction with deprecated `port`, the combined list will be exposed.
+  - This does not set a default for the admin port
 - `adminPort`
     - Integer
-    - If `port` is set, `adminPort` will default to `${port} + 1`
-    - If `port` is unset, `adminPort` has no default
+    - No default except for deprecated case described below
+    - _DEPRECATED_: If `port` is set, `adminPort` will default to `${port} + 1`
     - Exposed in dockerfile if set
 - `serviceName`
     - String

--- a/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplication.java
+++ b/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplication.java
@@ -12,6 +12,10 @@ public class HypertraceDockerJavaApplication {
   public final Property<String> baseImage;
   public final Property<String> maintainer;
   public final Property<String> serviceName;
+  /**
+   * Replaced by by {@link #ports}
+   */
+  @Deprecated
   public final Property<Integer> port;
   public final Property<Integer> adminPort;
   public final ListProperty<Integer> ports;

--- a/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplication.java
+++ b/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplication.java
@@ -13,7 +13,7 @@ public class HypertraceDockerJavaApplication {
   public final Property<String> maintainer;
   public final Property<String> serviceName;
   /**
-   * Replaced by by {@link #ports}
+   * Replaced by {@link #ports}
    */
   @Deprecated
   public final Property<Integer> port;


### PR DESCRIPTION
## Description
Deprecate `port` and update the docs to clarify relationship of `port` and `ports` based on feedback in #24 