### PR TITLE
feat: improve docker image layering by splitting libs

### DIFF
--- a/hypertrace-gradle-docker-java-application-plugin/src/main/resources/application-start-script.template.sh
+++ b/hypertrace-gradle-docker-java-application-plugin/src/main/resources/application-start-script.template.sh
@@ -25,4 +25,4 @@ set -e
 
 DEFAULT_JVM_OPTS=${defaultJvmOpts}
 
-exec java \$DEFAULT_JVM_OPTS \$JAVA_OPTS -classpath '/app/resources:/app/classes:/app/libs/*' ${mainClassName} \$@
+exec java \$DEFAULT_JVM_OPTS \$JAVA_OPTS -classpath '/app/resources:/app/classes:/app/localLibs/*:/app/externalLibs/*' ${mainClassName} \$@


### PR DESCRIPTION
## Description
Changed the layering the java application generated docker image to separate newly built jars in a layer above older jars. The thinking here is that in its current incarnation, all libs are in the same layer and since the version changes each time, that layer is always invalidated. Now, the expectation is external dependencies will still be cached as the changing jars are kept in a layer above.

### Testing
Built and inspected local images.

Example from attribute service, where the external libs and local libs are split to two different layers. The volatile local lib layer is much smaller:
<img width="697" alt="image" src="https://user-images.githubusercontent.com/45047841/184470001-8bfb90d3-1947-4561-ab68-69543b9e3da2.png">

```
|-- externalLibs
|   |-- HdrHistogram-2.1.12.jar
|   |-- LatencyUtils-2.0.3.jar
|   |-- animal-sniffer-annotations-1.19.jar
|   |-- annotations-4.1.1.4.jar
|   |-- bson-4.1.2.jar
|   |-- checker-qual-3.12.0.jar
|   |-- commons-codec-1.15.jar
|   |-- commons-collections4-4.4.jar
|   |-- commons-lang3-3.10.jar
|   |-- commons-logging-1.2.jar
|   |-- config-1.4.2.jar
|   |-- document-store-0.6.15.jar
|   |-- error_prone_annotations-2.11.0.jar
|   |-- failsafe-2.4.0.jar
|   |-- failureaccess-1.0.1.jar
|   |-- grpc-api-1.47.0.jar
|   |-- grpc-client-utils-0.7.5.jar
|   |-- grpc-context-1.47.0.jar
|   |-- grpc-context-utils-0.7.5.jar
|   |-- grpc-core-1.47.0.jar
|   |-- grpc-netty-1.47.0.jar
|   |-- grpc-protobuf-1.47.0.jar
|   |-- grpc-protobuf-lite-1.47.0.jar
|   |-- grpc-server-utils-0.7.5.jar
|   |-- grpc-services-1.47.0.jar
|   |-- grpc-stub-1.47.0.jar
|   |-- gson-2.9.0.jar
|   |-- guava-31.1-jre.jar
|   |-- guava-annotations-r03.jar
|   |-- httpclient-4.5.13.jar
|   |-- httpcore-4.4.13.jar
|   |-- j2objc-annotations-1.3.jar
|   |-- jackson-annotations-2.13.2.jar
|   |-- jackson-core-2.13.2.jar
|   |-- jackson-databind-2.13.2.2.jar
|   |-- java-jwt-3.19.1.jar
|   |-- javax.annotation-api-1.3.2.jar
|   |-- javax.servlet-api-3.1.0.jar
|   |-- jaxb-api-2.3.0.jar
|   |-- jetty-http-9.4.48.v20220622.jar
|   |-- jetty-io-9.4.48.v20220622.jar
|   |-- jetty-security-9.4.48.v20220622.jar
|   |-- jetty-server-9.4.48.v20220622.jar
|   |-- jetty-servlet-9.4.48.v20220622.jar
|   |-- jetty-util-9.4.48.v20220622.jar
|   |-- jetty-util-ajax-9.4.48.v20220622.jar
|   |-- jsr305-3.0.2.jar
|   |-- jwks-rsa-0.21.1.jar
|   |-- listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
|   |-- log4j-api-2.17.1.jar
|   |-- log4j-core-2.17.1.jar
|   |-- log4j-slf4j-impl-2.17.1.jar
|   |-- metrics-core-4.2.10.jar
|   |-- metrics-healthchecks-4.2.10.jar
|   |-- metrics-json-4.2.10.jar
|   |-- metrics-jvm-4.2.10.jar
|   |-- metrics-servlets-4.2.10.jar
|   |-- micrometer-core-1.7.5.jar
|   |-- micrometer-jvm-extras-0.2.0.jar
|   |-- micrometer-registry-prometheus-1.7.5.jar
|   |-- mongodb-driver-core-4.1.2.jar
|   |-- mongodb-driver-sync-4.1.2.jar
|   |-- netty-buffer-4.1.77.Final.jar
|   |-- netty-codec-4.1.77.Final.jar
|   |-- netty-codec-http-4.1.77.Final.jar
|   |-- netty-codec-http2-4.1.77.Final.jar
|   |-- netty-codec-socks-4.1.72.Final.jar
|   |-- netty-common-4.1.77.Final.jar
|   |-- netty-handler-4.1.77.Final.jar
|   |-- netty-handler-proxy-4.1.72.Final.jar
|   |-- netty-resolver-4.1.77.Final.jar
|   |-- netty-transport-4.1.77.Final.jar
|   |-- netty-transport-native-unix-common-4.1.72.Final.jar
|   |-- perfmark-api-0.25.0.jar
|   |-- platform-grpc-service-framework-0.1.37.jar
|   |-- platform-metrics-0.1.37.jar
|   |-- platform-service-framework-0.1.37.jar
|   |-- postgresql-42.3.3.jar
|   |-- profiler-1.1.1.jar
|   |-- proto-google-common-protos-2.0.1.jar
|   |-- protobuf-java-3.19.2.jar
|   |-- protobuf-java-util-3.19.2.jar
|   |-- service-framework-spi-0.1.37.jar
|   |-- simpleclient-0.12.0.jar
|   |-- simpleclient_common-0.12.0.jar
|   |-- simpleclient_dropwizard-0.12.0.jar
|   |-- simpleclient_pushgateway-0.12.0.jar
|   |-- simpleclient_servlet-0.12.0.jar
|   |-- simpleclient_servlet_common-0.12.0.jar
|   |-- simpleclient_tracer_common-0.12.0.jar
|   |-- simpleclient_tracer_otel-0.12.0.jar
|   |-- simpleclient_tracer_otel_agent-0.12.0.jar
|   `-- slf4j-api-1.7.36.jar
|-- localLibs
|   |-- attribute-service-api-0.14.4-SNAPSHOT.jar
|   |-- attribute-service-factory-0.14.4-SNAPSHOT.jar
|   |-- attribute-service-impl-0.14.4-SNAPSHOT.jar
|   `-- attribute-service-tenant-api-0.14.4-SNAPSHOT.jar
```