### PR TITLE
feat: add improved docker image layering

### DIFF
--- a/hypertrace-gradle-docker-java-application-plugin/CHANGELOG.md
+++ b/hypertrace-gradle-docker-java-application-plugin/CHANGELOG.md
@@ -1,23 +1,28 @@
 # Changelog
 
-
 ## [0.2.4]
+
 - Default image has changed from gcr.io/distroless/java:11 to gcr.io/distroless/java:11-debug
 
 ## [0.3.0]
+
 - Added support for producing multiple variants of an application with different base images
 - Added a default variant, `slim` based off `gcr.io/distroless/java:11`
 
 ## [0.3.2]
+
 - Removed default `slim` variant
 
 ## [0.3.3]
+
 - Support Java 8+
 
 ## [0.4.0]
+
 - Change default image to `hypertrace/java:11`
 
 ## [0.5.0]
+
 - Exposed for configuration:
     - `maintainer`
     - `port`
@@ -25,18 +30,32 @@
     - `serviceName`
     - `healthCheck`
     - `envVars`
+
 ## [0.7.0]
+
 - Remove variants
 - Remove internal usage of `com.bmuschko.docker-java-application`, cleaning up ghost tasks
 - Use gradle application start script to run application in docker, allowing reuse and accounting
   for env vars like JAVA_OPTS
 
 ## [0.7.1]
+
 - Simplify start script to use provided parameters as given
 
 ## [0.8.0]
+
 - Add COMMIT_SHA to the generated dockerfile as a build arg defaulting to unknown
 - Use COMMIT_SHA build arg to set a label `commit_sha` and environment variable `COMMIT_SHA`
 
 ## [0.8.2]
+
 - Add support for exposing multiple docker image ports via `ports` config
+
+## [0.9.6]
+
+- Improve docker layering by splitting libraries into 3 layers. From the top down:
+    - Local libraries being built as part of the target gradle build
+    - Organization libraries that satisfy the `orgLibrarySpec` property on the `javaApplication`
+      spec as documented in the README, but do not satisfy the local library criteria.
+    - External libraries, presumed to be any library that does not meet the criteria of either of
+      the above layers.

--- a/hypertrace-gradle-docker-java-application-plugin/README.md
+++ b/hypertrace-gradle-docker-java-application-plugin/README.md
@@ -1,11 +1,14 @@
-
 # Hypertrace Docker Java Application Plugin
+
 ###### org.hypertrace.docker-java-application-plugin
 
 ### Purpose
-This plugin is a highly opinionated plugin that configures the target project to build docker images of the target project.
-It configures the default image from `org.hypertrace.docker-plugin` to use the docker file produced by
-`com.bmuschko.docker-java-application`. It allows configuring several values, detailed below. 
+
+This plugin is a highly opinionated plugin that configures the target project to build docker images
+of the target project.
+It configures the default image from `org.hypertrace.docker-plugin` to use the docker file produced
+by
+`com.bmuschko.docker-java-application`. It allows configuring several values, detailed below.
 Additionally, the main class is taken from the application plugin - the
 default behavior of `com.bmuschko.docker-java-application` for identifying main classes is not used.
 An application can define multiple variants which allow specifying different base images to use.
@@ -19,12 +22,14 @@ An application can define multiple variants which allow specifying different bas
 - `port` (_DEPRECATED_ - replaced by `ports`)
     - Integer
     - No default
-    - Exposed in dockerfile if set. If used in conjunction with `ports`, the combined list will be exposed.
+    - Exposed in dockerfile if set. If used in conjunction with `ports`, the combined list will be
+      exposed.
 - `ports`
-  - Integer List
-  - No default
-  - Exposed in dockerfile if set. If used in conjunction with deprecated `port`, the combined list will be exposed.
-  - This does not set a default for the admin port
+    - Integer List
+    - No default
+    - Exposed in dockerfile if set. If used in conjunction with deprecated `port`, the combined list
+      will be exposed.
+    - This does not set a default for the admin port
 - `adminPort`
     - Integer
     - No default except for deprecated case described below
@@ -36,13 +41,19 @@ An application can define multiple variants which allow specifying different bas
     - Added to envVars as `SERVICE_NAME`
 - `healthCheck`
     - String
-    - If `adminPort` is set, defaults to `-interval=2s --start-period=15s --timeout=2s CMD wget  -qO http://127.0.0.1:${adminPort}/health &> /dev/null || exit`
+    - If `adminPort` is set, defaults
+      to `-interval=2s --start-period=15s --timeout=2s CMD wget -qO http://127.0.0.1:${adminPort}/health &> /dev/null || exit`
     - If `adminPort` is unset, `healthCheck` has no default
 - `envVars`
     - Map<String, String>
     - Defaults to `{"SERVICE_NAME": "${serviceName}"}`
     - Can be appended to with `put`, or overwritten with `set`
-
+- `orgLibrarySpec`
+    - `Spec<ResolvedArtifact>`
+    - Defaults to any artifact with a group starting with `org.hypertrace`
+    - This is used in layering the image to separate org libraries into a layer above external
+      libraries, under the assumption these will change (and thus invalidate the layer) more
+      frequently.
 
 For further configuration, use `org.hypertrace.docker-plugin` directly and create a dockerfile.
 
@@ -68,6 +79,7 @@ hypertraceDocker {
 ```
 
 Producing a dockerfile:
+
 ```Dockerfile
 FROM hypertrace/java:11
 LABEL maintainer="Hypertrace 'https://www.hypertrace.org/'"
@@ -82,6 +94,7 @@ ENV SERVICE_NAME=example-app
 ```
 
 Overriding or providing more variables:
+
 ```kotlin
 hypertraceDocker {
   defaultImage {
@@ -96,6 +109,7 @@ hypertraceDocker {
 ```
 
 Produces a diff of:
+
 ```diff
 -FROM hypertrace/java:11
 +FROM hypertrace/java:14

--- a/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplication.java
+++ b/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplication.java
@@ -2,10 +2,12 @@ package org.hypertrace.gradle.docker;
 
 import java.util.Collections;
 import javax.inject.Inject;
+import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.specs.Spec;
 
 public class HypertraceDockerJavaApplication {
 
@@ -21,6 +23,7 @@ public class HypertraceDockerJavaApplication {
   public final ListProperty<Integer> ports;
   public final Property<String> healthCheck;
   public final MapProperty<String, String> envVars;
+  public Spec<ResolvedArtifact> orgLibrarySpec;
 
   @Inject
   public HypertraceDockerJavaApplication(
@@ -42,5 +45,13 @@ public class HypertraceDockerJavaApplication {
     this.healthCheck = objectFactory.property(String.class)
                                     .convention(this.adminPort.map(adminPort -> String.format(
                                         "HEALTHCHECK --interval=2s --start-period=15s --timeout=2s CMD wget -qO- http://127.0.0.1:%d/health &> /dev/null || exit 1", adminPort)));
+    this.orgLibrarySpec = this::isHypertraceLibrary;
+  }
+
+  private boolean isHypertraceLibrary(ResolvedArtifact artifact) {
+    return artifact.getModuleVersion()
+                   .getId()
+                   .getGroup()
+                   .startsWith("org.hypertrace");
   }
 }

--- a/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplicationPlugin.java
+++ b/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplicationPlugin.java
@@ -154,6 +154,7 @@ public class HypertraceDockerJavaApplicationPlugin implements Plugin<Project> {
   private void createDockerStartScriptTask(Project project) {
     project.getTasks()
            .register(DOCKER_START_SCRIPT_TASK_NAME, CreateStartScripts.class, startScript -> {
+             startScript.getInputs().file(this.getStartScriptTemplate(project));
              ((TemplateBasedScriptGenerator) startScript.getUnixStartScriptGenerator()).setTemplate(this.getStartScriptTemplate(project));
              startScript.setGroup(DockerPlugin.TASK_GROUP);
              startScript.setDescription("Creates a startup script for use by the docker container");

--- a/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplicationPlugin.java
+++ b/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplicationPlugin.java
@@ -12,19 +12,22 @@ import com.bmuschko.gradle.docker.tasks.image.Dockerfile.From;
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Path;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.file.Directory;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.ApplicationPlugin;
 import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.resources.TextResource;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.Sync;
@@ -37,9 +40,9 @@ public class HypertraceDockerJavaApplicationPlugin implements Plugin<Project> {
   public static final String DOCKERFILE_TASK_NAME = "generateJavaApplicationDockerfile";
   public static final String DOCKER_START_SCRIPT_TASK_NAME = "generateJavaApplicationDockerStartScript";
   public static final String SYNC_BUILD_CONTEXT_TASK_NAME = "syncJavaApplicationDockerContext";
-  private static final String DOCKER_BUILD_CONTEXT_EXTERNAL_LIBS_DIR = "externalLibs";
-
   private static final String DOCKER_BUILD_CONTEXT_LOCAL_LIBS_DIR = "localLibs";
+  private static final String DOCKER_BUILD_CONTEXT_ORG_LIBS_DIR = "orgLibs";
+  private static final String DOCKER_BUILD_CONTEXT_EXTERNAL_LIBS_DIR = "externalLibs";
   private static final String DOCKER_BUILD_CONTEXT_CLASSES_DIR = "classes";
   private static final String DOCKER_BUILD_CONTEXT_RESOURCES_DIR = "resources";
   private static final String DOCKER_BUILD_CONTEXT_SCRIPTS_DIR = "scripts";
@@ -120,6 +123,9 @@ public class HypertraceDockerJavaApplicationPlugin implements Plugin<Project> {
                                                                     .map(dir -> dir.dir(DOCKER_BUILD_CONTEXT_EXTERNAL_LIBS_DIR)))
                  .map(unused -> new CopyFile(DOCKER_BUILD_CONTEXT_EXTERNAL_LIBS_DIR, DOCKER_BUILD_CONTEXT_EXTERNAL_LIBS_DIR)));
              dockerfile.copyFile(provideIfDirectoryExists(dockerfile.getDestDir()
+                                                                    .map(dir -> dir.dir(DOCKER_BUILD_CONTEXT_ORG_LIBS_DIR)))
+                 .map(unused -> new CopyFile(DOCKER_BUILD_CONTEXT_ORG_LIBS_DIR, DOCKER_BUILD_CONTEXT_ORG_LIBS_DIR)));
+             dockerfile.copyFile(provideIfDirectoryExists(dockerfile.getDestDir()
                                                                     .map(dir -> dir.dir(DOCKER_BUILD_CONTEXT_LOCAL_LIBS_DIR)))
                  .map(unused -> new CopyFile(DOCKER_BUILD_CONTEXT_LOCAL_LIBS_DIR, DOCKER_BUILD_CONTEXT_LOCAL_LIBS_DIR)));
              dockerfile.copyFile(provideIfDirectoryExists(dockerfile.getDestDir()
@@ -178,22 +184,32 @@ public class HypertraceDockerJavaApplicationPlugin implements Plugin<Project> {
                            .map(Dockerfile::getDestDir)
                            .get());
              sync.with(project.copySpec(spec -> {
-               // We split deps into two dirs depending on last modified time, with the assumption that any local jars will be recently built
-               Instant time = Instant.now()
-                                     .minus(30, ChronoUnit.MINUTES);
-               spec.into(DOCKER_BUILD_CONTEXT_LOCAL_LIBS_DIR, childSpec -> childSpec.from(getRuntimeClasspath(project)
-                   .filter(file -> Instant.ofEpochMilli(file.lastModified())
-                                          .isAfter(time))));
-               spec.into(DOCKER_BUILD_CONTEXT_EXTERNAL_LIBS_DIR, childSpec -> childSpec.from(getRuntimeClasspath(project)
-                   .filter(file -> Instant.ofEpochMilli(file.lastModified())
-                                          .isBefore(time))));
+               spec.into(DOCKER_BUILD_CONTEXT_LOCAL_LIBS_DIR, childSpec -> childSpec.from(this.buildFilteredLibraryProvider(project, this.buildLocalArtifactPredicate(project))));
+               spec.into(DOCKER_BUILD_CONTEXT_ORG_LIBS_DIR, childSpec -> childSpec.from(this.buildFilteredLibraryProvider(project, this.buildLocalArtifactPredicate(project)
+                                                                                                                                       .negate()
+                                                                                                                                       .and(this.getOrgLibPredicate(project)))));
+               spec.into(DOCKER_BUILD_CONTEXT_EXTERNAL_LIBS_DIR, childSpec -> childSpec.from(this.buildFilteredLibraryProvider(project, this.buildLocalArtifactPredicate(project)
+                                                                                                                                            .negate()
+                                                                                                                                            .and(this.getOrgLibPredicate(project)
+                                                                                                                                                     .negate()))));
                spec.into(DOCKER_BUILD_CONTEXT_CLASSES_DIR, childSpec -> childSpec.from(mainSourceSetOutput(project).getClassesDirs()));
                spec.into(DOCKER_BUILD_CONTEXT_RESOURCES_DIR, childSpec -> childSpec.from(mainSourceSetOutput(project).getResourcesDir()));
              }));
            });
   }
 
-  private FileCollection getRuntimeClasspath(Project project) {
+  private Predicate<ResolvedArtifact> buildLocalArtifactPredicate(Project project) {
+    // Either matching version or missing version indicating a composite project
+    return artifact -> {
+      String artifactVersion = artifact.getModuleVersion()
+                                       .getId()
+                                       .getVersion();
+      return artifactVersion.equals(project.getVersion()
+                                           .toString()) || artifactVersion.equals("unspecified");
+    };
+  }
+
+  private Configuration getRuntimeClasspath(Project project) {
     return project.getConfigurations()
                   .getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME);
   }
@@ -217,5 +233,19 @@ public class HypertraceDockerJavaApplicationPlugin implements Plugin<Project> {
     return project.getResources()
                   .getText()
                   .fromUri(requireNonNull(resourceUrl));
+  }
+
+  private Provider<Collection<File>> buildFilteredLibraryProvider(Project project, Predicate<ResolvedArtifact> filterPredicate) {
+    return project.provider(() -> this.getRuntimeClasspath(project)
+                                      .getResolvedConfiguration()
+                                      .getResolvedArtifacts()
+                                      .stream()
+                                      .filter(filterPredicate)
+                                      .map(ResolvedArtifact::getFile)
+                                      .collect(Collectors.toSet()));
+  }
+
+  private Predicate<ResolvedArtifact> getOrgLibPredicate(Project project) {
+    return this.getHypertraceDockerApplicationExtension(project).orgLibrarySpec::isSatisfiedBy;
   }
 }

--- a/hypertrace-gradle-docker-java-application-plugin/src/main/resources/application-start-script.template.sh
+++ b/hypertrace-gradle-docker-java-application-plugin/src/main/resources/application-start-script.template.sh
@@ -25,4 +25,4 @@ set -e
 
 DEFAULT_JVM_OPTS=${defaultJvmOpts}
 
-exec java \$DEFAULT_JVM_OPTS \$JAVA_OPTS -classpath '/app/resources:/app/classes:/app/localLibs/*:/app/externalLibs/*' ${mainClassName} \$@
+exec java \$DEFAULT_JVM_OPTS \$JAVA_OPTS -classpath '/app/resources:/app/classes:/app/localLibs/*:/app/orgLibs/*:/app/externalLibs/*' ${mainClassName} \$@


### PR DESCRIPTION
## Description

This change improves the image layering to split the libraries into 3 layers:
- localLibs - these libraries are part of the project, as determined by the heuristic that they either have no version (in the case of composite projects), or their version matches the target project.
- orgLibs - these libraries are part of the organization, as determined by the configurable spec `orgLibrarySpec` (which defaults to match libraries with a group starting with "org.hypertrace" 
- externalLibs - all other libraries

The previous iteration of this did not work correctly as it used file modification times, which are dependent on the local state of files (e.g. cached vs just downloaded).

### Testing

Tested locally. Example from gateway service:

File tree:
```
|-- externalLibs
|   |-- HdrHistogram-2.1.12.jar
|   |-- LatencyUtils-2.0.3.jar
|   |-- animal-sniffer-annotations-1.19.jar
|   |-- annotations-4.1.1.4.jar
|   |-- checker-qual-3.12.0.jar
|   |-- commons-codec-1.15.jar
|   |-- commons-lang3-3.12.0.jar
|   |-- commons-logging-1.2.jar
|   |-- commons-math3-3.6.1.jar
|   |-- config-1.4.2.jar
|   |-- error_prone_annotations-2.11.0.jar
|   |-- failureaccess-1.0.1.jar
|   |-- grpc-api-1.47.0.jar
|   |-- grpc-context-1.47.0.jar
|   |-- grpc-core-1.47.0.jar
|   |-- grpc-netty-1.47.0.jar
|   |-- grpc-protobuf-1.47.0.jar
|   |-- grpc-protobuf-lite-1.47.0.jar
|   |-- grpc-services-1.47.0.jar
|   |-- grpc-stub-1.47.0.jar
|   |-- gson-2.9.0.jar
|   |-- guava-31.1-jre.jar
|   |-- httpclient-4.5.13.jar
|   |-- httpcore-4.4.13.jar
|   |-- j2objc-annotations-1.3.jar
|   |-- jackson-annotations-2.13.2.jar
|   |-- jackson-core-2.13.2.jar
|   |-- jackson-databind-2.13.2.2.jar
|   |-- java-jwt-3.19.1.jar
|   |-- javax.annotation-api-1.3.2.jar
|   |-- javax.servlet-api-3.1.0.jar
|   |-- jaxb-api-2.3.0.jar
|   |-- jetty-http-9.4.48.v20220622.jar
|   |-- jetty-io-9.4.48.v20220622.jar
|   |-- jetty-security-9.4.48.v20220622.jar
|   |-- jetty-server-9.4.48.v20220622.jar
|   |-- jetty-servlet-9.4.48.v20220622.jar
|   |-- jetty-util-9.4.48.v20220622.jar
|   |-- jetty-util-ajax-9.4.48.v20220622.jar
|   |-- jsr305-3.0.2.jar
|   |-- jwks-rsa-0.21.1.jar
|   |-- listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
|   |-- log4j-api-2.17.1.jar
|   |-- log4j-core-2.17.1.jar
|   |-- log4j-slf4j-impl-2.17.1.jar
|   |-- metrics-core-4.2.10.jar
|   |-- metrics-healthchecks-4.2.10.jar
|   |-- metrics-json-4.2.10.jar
|   |-- metrics-jvm-4.2.10.jar
|   |-- metrics-servlets-4.2.10.jar
|   |-- micrometer-core-1.7.5.jar
|   |-- micrometer-jvm-extras-0.2.0.jar
|   |-- micrometer-registry-prometheus-1.7.5.jar
|   |-- netty-buffer-4.1.77.Final.jar
|   |-- netty-codec-4.1.77.Final.jar
|   |-- netty-codec-http-4.1.77.Final.jar
|   |-- netty-codec-http2-4.1.77.Final.jar
|   |-- netty-codec-socks-4.1.72.Final.jar
|   |-- netty-common-4.1.77.Final.jar
|   |-- netty-handler-4.1.77.Final.jar
|   |-- netty-handler-proxy-4.1.72.Final.jar
|   |-- netty-resolver-4.1.77.Final.jar
|   |-- netty-transport-4.1.77.Final.jar
|   |-- netty-transport-native-unix-common-4.1.72.Final.jar
|   |-- perfmark-api-0.25.0.jar
|   |-- profiler-1.1.1.jar
|   |-- proto-google-common-protos-2.0.1.jar
|   |-- protobuf-java-3.19.4.jar
|   |-- protobuf-java-util-3.19.4.jar
|   |-- simpleclient-0.12.0.jar
|   |-- simpleclient_common-0.12.0.jar
|   |-- simpleclient_dropwizard-0.12.0.jar
|   |-- simpleclient_pushgateway-0.12.0.jar
|   |-- simpleclient_servlet-0.12.0.jar
|   |-- simpleclient_servlet_common-0.12.0.jar
|   |-- simpleclient_tracer_common-0.12.0.jar
|   |-- simpleclient_tracer_otel-0.12.0.jar
|   |-- simpleclient_tracer_otel_agent-0.12.0.jar
|   `-- slf4j-api-1.7.36.jar
|-- localLibs
|   |-- gateway-service-api-0.2.11-SNAPSHOT.jar
|   |-- gateway-service-baseline-lib-0.2.11-SNAPSHOT.jar
|   |-- gateway-service-factory-0.2.11-SNAPSHOT.jar
|   `-- gateway-service-impl-0.2.11-SNAPSHOT.jar
|-- orgLibs
|   |-- attribute-service-api-0.13.13.jar
|   |-- attribute-service-client-0.13.13.jar
|   |-- entity-service-api-0.8.27.jar
|   |-- entity-service-client-0.8.27.jar
|   |-- grpc-client-utils-0.7.5.jar
|   |-- grpc-context-utils-0.7.5.jar
|   |-- grpc-server-utils-0.7.5.jar
|   |-- platform-grpc-service-framework-0.1.37.jar
|   |-- platform-metrics-0.1.37.jar
|   |-- platform-service-framework-0.1.37.jar
|   |-- query-service-api-0.8.0.jar
|   |-- query-service-client-0.8.0.jar
|   `-- service-framework-spi-0.1.37.jar
```


![image](https://user-images.githubusercontent.com/45047841/185403116-62b6d449-cf5f-4ef4-ba6e-ea407f6b0e36.png)
