### PR TITLE
fix: depend on classpath to sync context

### DIFF
--- a/hypertrace-gradle-docker-java-application-plugin/CHANGELOG.md
+++ b/hypertrace-gradle-docker-java-application-plugin/CHANGELOG.md
@@ -51,7 +51,7 @@
 
 - Add support for exposing multiple docker image ports via `ports` config
 
-## [0.9.6]
+## [0.9.7]
 
 - Improve docker layering by splitting libraries into 3 layers. From the top down:
     - Local libraries being built as part of the target gradle build
@@ -59,3 +59,4 @@
       spec as documented in the README, but do not satisfy the local library criteria.
     - External libraries, presumed to be any library that does not meet the criteria of either of
       the above layers.
+- First appeared in 0.9.5, but bugs prevent correct execution until 0.9.7

--- a/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplicationPlugin.java
+++ b/hypertrace-gradle-docker-java-application-plugin/src/main/java/org/hypertrace/gradle/docker/HypertraceDockerJavaApplicationPlugin.java
@@ -154,7 +154,8 @@ public class HypertraceDockerJavaApplicationPlugin implements Plugin<Project> {
   private void createDockerStartScriptTask(Project project) {
     project.getTasks()
            .register(DOCKER_START_SCRIPT_TASK_NAME, CreateStartScripts.class, startScript -> {
-             startScript.getInputs().file(this.getStartScriptTemplate(project));
+             startScript.getInputs()
+                        .file(this.getStartScriptTemplate(project));
              ((TemplateBasedScriptGenerator) startScript.getUnixStartScriptGenerator()).setTemplate(this.getStartScriptTemplate(project));
              startScript.setGroup(DockerPlugin.TASK_GROUP);
              startScript.setDescription("Creates a startup script for use by the docker container");
@@ -178,7 +179,7 @@ public class HypertraceDockerJavaApplicationPlugin implements Plugin<Project> {
   private void createContextSyncTask(Project project) {
     project.getTasks()
            .register(SYNC_BUILD_CONTEXT_TASK_NAME, Sync.class, sync -> {
-             sync.dependsOn(CLASSES_TASK_NAME);
+             sync.dependsOn(CLASSES_TASK_NAME, this.getRuntimeClasspath(project));
              sync.setGroup(DockerPlugin.TASK_GROUP);
              sync.setDescription("Copies required artifacts into the build context directory");
              sync.into(this.getDockerfileTask(project)


### PR DESCRIPTION
## Description
In the previous release, we resolve the configuration in order to inspect the metadata of each dependency, transitive or otherwise. In order to do this without forcing resolution unnecessarily, we put it in a lazy provider. The issue this introduced is that now gradle does not know that this task depends on the configuration, since it's only referenced inside the provider. To resolve, we explicitly declare the runtime classpath as a dependency, which means that it will be fully built before executing the sync task.

### Testing
Reran earlier tests, but this time with a clean local state
